### PR TITLE
Use correct string types for control parameters

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -24,7 +24,7 @@
 */
 
 import { LIBUSB_ENDPOINT_IN } from "usb";
-import { USBDirection, USBRecipient } from "./enums";
+import { USBDirection } from "./enums";
 import {
     USBControlTransferParameters,
     USBInTransferResult,
@@ -213,13 +213,13 @@ export class USBDevice {
     }
 
     private setupInvalid(setup: USBControlTransferParameters): string {
-        if (setup.recipient & USBRecipient.interface) {
+        if (setup.recipient === "interface") {
             const interfaceNumber = setup.index & 0xff; // lower 8 bits
             const iface = this.configuration.interfaces.find(usbInterface => usbInterface.interfaceNumber === interfaceNumber);
             if (!iface) return "interface not found";
             if (!iface.claimed) return "invalid state";
 
-        } else if (setup.recipient & USBRecipient.endpoint) {
+        } else if (setup.recipient === "endpoint") {
             const endpointNumber = setup.index & 0x0f; // lower 4 bits
             const direction = setup.index & LIBUSB_ENDPOINT_IN ? "in" : "out";
 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -26,21 +26,12 @@
 /**
  * Request type
  */
-export enum USBRequestType {
-    standard = 0x00,
-    class = 0x20,
-    vendor = 0x40
-}
+export type USBRequestType = "standard" | "class" | "vendor";
 
 /**
  * Recipient
  */
-export enum USBRecipient {
-    device = 0x00,
-    interface = 0x01,
-    endpoint = 0x02,
-    other = 0x03
-}
+export type USBRecipient = "device" | "interface" | "endpoint" | "other";
 
 /**
  * Transfer status


### PR DESCRIPTION
Switch to using correct string types for control parameters instead of enums