### PR TITLE
Reject with error on adapter.open()

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -570,8 +570,8 @@ export class USBAdapter extends EventEmitter implements Adapter {
             const device = this.getDevice(handle);
             try {
                 device.open();
-            } catch (_e) {
-                reject();
+            } catch (error) {
+                return reject(error);
             }
             resolve();
         });


### PR DESCRIPTION
I could not call `open()` on one of my devices, and got only an `undefined` error object in the catch. The correct error `LIBUSB_ERROR_ACCESS` would have helped me to easily understand that I would have to call my script as root. This PR raises the catched error.