### PR TITLE
Remove iface.claimed check on control transfers

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -217,7 +217,6 @@ export class USBDevice {
             const interfaceNumber = setup.index & 0xff; // lower 8 bits
             const iface = this.configuration.interfaces.find(usbInterface => usbInterface.interfaceNumber === interfaceNumber);
             if (!iface) return "interface not found";
-            if (!iface.claimed) return "invalid state";
 
         } else if (setup.recipient === "endpoint") {
             const endpointNumber = setup.index & 0x0f; // lower 4 bits
@@ -225,7 +224,6 @@ export class USBDevice {
 
             const result = this.getEndpoint(direction, endpointNumber);
             if (!result.endpoint) return "endpoint not found";
-            if (!result.iface.claimed) return "invalid state";
         }
     }
 


### PR DESCRIPTION
These checks aren't necessary (aren't mentioned in the latest version of the spec). I have a use-case of adjusting camera settings on a UVC (USB Video Class) device, and have confirmed it works fine without claiming the interface (in addition to verifying in other libraries which don't claim the interface before the control transfers).