### PR TITLE
Resolve with stall status instead of rejecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.54",
-    "@types/usb": "^1.1.6",
+    "@types/usb": "^1.1.7",
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-sourcemaps": "^2.6.1",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -698,7 +698,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
             device.controlTransfer(type, setup.request, setup.value, setup.index, length, (error, buffer) => {
                 if (error) {
-                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                    if (error.errno === LIBUSB_TRANSFER_STALL) {
                         return resolve({
                             status: "stall"
                         });
@@ -723,7 +723,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
             device.controlTransfer(type, setup.request, setup.value, setup.index, buffer, error => {
                 if (error) {
-                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                    if (error.errno === LIBUSB_TRANSFER_STALL) {
                         return resolve({
                             bytesWritten: 0,
                             status: "stall"
@@ -759,7 +759,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
             endpoint.transfer(length, (error, data) => {
                 if (error) {
-                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                    if (error.errno === LIBUSB_TRANSFER_STALL) {
                         return resolve({
                             status: "stall"
                         });
@@ -784,7 +784,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
             endpoint.transfer(buffer, error => {
                 if (error) {
-                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                    if (error.errno === LIBUSB_TRANSFER_STALL) {
                         return resolve({
                             bytesWritten: 0,
                             status: "stall"

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -36,6 +36,7 @@ import {
     LIBUSB_ENDPOINT_IN,
     LIBUSB_ENDPOINT_OUT,
     LIBUSB_REQUEST_GET_DESCRIPTOR,
+    LIBUSB_TRANSFER_STALL,
     LIBUSB_TRANSFER_TYPE_INTERRUPT,
     LIBUSB_TRANSFER_TYPE_BULK,
     LIBUSB_RECIPIENT_DEVICE,
@@ -696,7 +697,16 @@ export class USBAdapter extends EventEmitter implements Adapter {
             const type = this.controlTransferParamsToType(setup, LIBUSB_ENDPOINT_IN);
 
             device.controlTransfer(type, setup.request, setup.value, setup.index, length, (error, buffer) => {
-                if (error) return reject(error);
+                if (error) {
+                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                        return resolve({
+                            status: "stall"
+                        });
+                    }
+
+                    return reject(error);
+                }
+
                 resolve({
                     data: this.bufferToDataView(buffer),
                     status: "ok" // hack
@@ -712,7 +722,17 @@ export class USBAdapter extends EventEmitter implements Adapter {
             const buffer = data ? this.bufferSourceToBuffer(data) : new Buffer(0);
 
             device.controlTransfer(type, setup.request, setup.value, setup.index, buffer, error => {
-                if (error) return reject(error);
+                if (error) {
+                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                        return resolve({
+                            bytesWritten: 0,
+                            status: "stall"
+                        });
+                    }
+
+                    return reject(error);
+                }
+
                 resolve({
                     bytesWritten: buffer.byteLength, // hack, should be bytes actually written
                     status: "ok" // hack
@@ -738,7 +758,16 @@ export class USBAdapter extends EventEmitter implements Adapter {
             const endpoint = this.getInEndpoint(device, endpointNumber);
 
             endpoint.transfer(length, (error, data) => {
-                if (error) return reject(error);
+                if (error) {
+                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                        return resolve({
+                            status: "stall"
+                        });
+                    }
+
+                    return reject(error);
+                }
+
                 resolve({
                     data: this.bufferToDataView(data),
                     status: "ok" // hack
@@ -754,7 +783,17 @@ export class USBAdapter extends EventEmitter implements Adapter {
             const buffer = this.bufferSourceToBuffer(data);
 
             endpoint.transfer(buffer, error => {
-                if (error) return reject(error);
+                if (error) {
+                    if (error.errno == LIBUSB_TRANSFER_STALL) {
+                        return resolve({
+                            bytesWritten: 0,
+                            status: "stall"
+                        });
+                    }
+
+                    return reject(error);
+                }
+
                 resolve({
                     bytesWritten: buffer.byteLength, // hack, should be bytes actually written
                     status: "ok" // hack


### PR DESCRIPTION
Per the spec, transfers should resolve with status `stall` if there's a stall.

The spec also mentions `babble` for transfers in, but I didn't implement that in this PR as it wasn't my immediate need.

Open question, it's not clear to me if transfers in can stall but have received partial data. If that's true, then `data` should be set for those.