### PR TITLE
Release interfaces on Device.close()

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -253,7 +253,12 @@ export class USBDevice {
             if (!this.connected) return reject(new Error("close error: device not found"));
             if (!this.opened) return resolve();
 
-            adapter.close(this._handle)
+            const releaseInterfacePromises = this.configuration.interfaces.map(
+                iface => this.releaseInterface(iface.interfaceNumber));
+
+            Promise.all(releaseInterfacePromises)
+            .catch(_error => { /* Ignore */ })
+            .then(() => adapter.close(this._handle))
             .then(resolve)
             .catch(error => {
                 reject(new Error(`close error: ${error}`));


### PR DESCRIPTION
This PR might not be perfect, kinda rushed it as the issue cropped up while I was swamped with other stuff.

Per the spec, close should release any claimed interfaces. Rather than check if it's claimed, I decided to try to release all interfaces and let `releaseInterface` simply ignore the ones which aren't claimed. Checking first is also perfectly reasonable.

Swallows any errors during release, as the spec doesn't mention throwing any errors here, and it wouldn't make sense to stop the close. Could definitely have better error handling.

Best way to reproduce the current bug is to claim an interface but don't release it, close the device, re-open the device, then try to close the interface (which will still be marked as claimed). Should result in a libusb not found error.