### PR TITLE
Map LIBUSB_TRANSFER_OVERFLOW to "babble" status

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ https://wicg.github.io/webusb/
 - [x] claimInterface()
 - [x] releaseInterface()
 - [x] selectAlternateInterface()
-- [x] controlTransferIn() - always returns `status` "ok"
+- [x] controlTransferIn()
 - [x] controlTransferOut() - always returns `status` "ok", `bytesWritten` always equals the initial buffer length
-- [x] transferIn() - always returns `status` "ok"
+- [x] transferIn()
 - [x] transferOut() - always returns `status` "ok", `bytesWritten` always equals the initial buffer length
 - [x] clearHalt()
 - [x] reset()

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -714,7 +714,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
                 resolve({
                     data: this.bufferToDataView(buffer),
-                    status: "ok" // hack
+                    status: "ok"
                 });
             });
         });
@@ -779,7 +779,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
                 resolve({
                     data: this.bufferToDataView(data),
-                    status: "ok" // hack
+                    status: "ok"
                 });
             });
         });

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -36,6 +36,7 @@ import {
     LIBUSB_ENDPOINT_IN,
     LIBUSB_ENDPOINT_OUT,
     LIBUSB_REQUEST_GET_DESCRIPTOR,
+    LIBUSB_TRANSFER_OVERFLOW,
     LIBUSB_TRANSFER_STALL,
     LIBUSB_TRANSFER_TYPE_INTERRUPT,
     LIBUSB_TRANSFER_TYPE_BULK,
@@ -702,6 +703,10 @@ export class USBAdapter extends EventEmitter implements Adapter {
                         return resolve({
                             status: "stall"
                         });
+                    } else if (error.errno === LIBUSB_TRANSFER_OVERFLOW) {
+                        return resolve({
+                            status: "babble"
+                        });
                     }
 
                     return reject(error);
@@ -762,6 +767,10 @@ export class USBAdapter extends EventEmitter implements Adapter {
                     if (error.errno === LIBUSB_TRANSFER_STALL) {
                         return resolve({
                             status: "stall"
+                        });
+                    } else if (error.errno === LIBUSB_TRANSFER_OVERFLOW) {
+                        return resolve({
+                            status: "babble"
                         });
                     }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -361,8 +361,6 @@ export class USBDevice {
     /**
      * Undertake a control transfer in from the device
      *
-     * __Note:__ The transfer result currently has a status always set to "ok"
-     *
      * @param setup The USB control transfer parameters
      * @param length The amount of data to transfer
      * @returns Promise containing a result
@@ -433,8 +431,6 @@ export class USBDevice {
 
     /**
      * Undertake a transfer in from the device
-     *
-     * __Note:__ The transfer result currently has a status always set to "ok"
      *
      * @param endpointNumber The number of the endpoint to transfer from
      * @param length The amount of data to transfer


### PR DESCRIPTION
Similar to #37, but resolves LIBUSB_TRANSFER_OVERFLOW errors in `controlTransferIn` and `transferIn` to status `"babble"`.

I've also updated the read me to remove the statement  `always returns `status` "ok"` as now `"stalled"` (#37) and  `"babble"` are returned.