### PR TITLE
Only attach node-usb attach/detach listeners when there is a connect/disconnected listener

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -33,6 +33,7 @@ import {
     ConfigDescriptor,
     InterfaceDescriptor,
     on,
+    removeListener,
     LIBUSB_ENDPOINT_IN,
     LIBUSB_ENDPOINT_OUT,
     LIBUSB_REQUEST_GET_DESCRIPTOR,
@@ -126,7 +127,7 @@ export class USBAdapter extends EventEmitter implements Adapter {
     constructor() {
         super();
 
-        on("attach", device => {
+        const attachCallback = device => {
             this.loadDevice(device, DEFAULT_RETRY_COUNT)
             .then(loadedDevice => {
                 if (loadedDevice) {
@@ -139,14 +140,42 @@ export class USBAdapter extends EventEmitter implements Adapter {
                     });
                 }
             });
-        });
+        };
 
-        on("detach", device => {
+        const detachCallback = device => {
             const handle = this.getDeviceHandle(device);
 
             if (handle && this.devices[handle]) {
                 delete this.devices[handle];
                 this.emit(USBAdapter.EVENT_DEVICE_DISCONNECT, handle);
+            }
+        };
+
+        this.on("newListener", event => {
+            const listenerCount = this.listenerCount(event);
+
+            if (listenerCount !== 0) {
+                return;
+            }
+
+            if (event === USBAdapter.EVENT_DEVICE_CONNECT) {
+                on("attach", attachCallback);
+            } else if (event === USBAdapter.EVENT_DEVICE_DISCONNECT) {
+                on("detach", detachCallback);
+            }
+        });
+
+        this.on("removeListener", event => {
+            const listenerCount = this.listenerCount(event);
+
+            if (listenerCount !== 0) {
+                return;
+            }
+
+            if (event === USBAdapter.EVENT_DEVICE_CONNECT) {
+                removeListener("attach", attachCallback);
+            } else if (event === USBAdapter.EVENT_DEVICE_DISCONNECT) {
+                removeListener("detach", detachCallback);
             }
         });
     }


### PR DESCRIPTION
Depends on https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32106

These changes only add the `usb` "attach"/"detach" handlers if a listener is "connected"/"disconnected".

It allows apps that don't listen to these events to exit automatically, as well as exit automatically if listeners for both events are not attached.

`node-usb` uses a similar pattern here: https://github.com/tessel/node-usb/blob/master/usb.js#L511-L524