### PR TITLE
Resolve all device.getStringDescriptor() errors to empty string

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -510,13 +510,12 @@ export class USBAdapter extends EventEmitter implements Adapter {
     }
 
     private getStringDescriptor(device: Device, index: number): Promise<string> {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
             this.openDevice(device)
             .then(() => {
                 device.getStringDescriptor(index, (error, buffer) => {
                     device.close();
-                    if (error) return reject(error);
-                    resolve(buffer.toString());
+                    resolve(error ? "" : buffer.toString());
                 });
             })
             .catch(_error => {


### PR DESCRIPTION
I'm using a somewhat flaky USB device, that gets various errors when getting string descriptors, and these errors cause `usb.requestDevice(options)` to not report the device - however using WebUSB in a browser reports the device.

I think the intention of adapter's `getStringDescriptor` was to map all errors to an empty string result, based on the catch code.