### PR TITLE
Fix: Unhandled Promised rejection.

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -236,7 +236,8 @@ export class USBAdapter extends EventEmitter implements Adapter {
 
                 return this.delay(timeout)
                 .then(() => this.retryPromise(fn, --retries, timeout))
-                .then(resolve);
+                .then(resolve)
+                .catch(retryError => reject(retryError));
             });
         });
     }


### PR DESCRIPTION
Rejection from `retryPromise` is not handled from time to time. I noticed this when testing `connect`, `disconnect` listeners and rapidly connect/disconnect usb device. (Actually it's changing interface)

I believe rewrite to `async/await`(https://github.com/thegecko/webusb/issues/54) will help catch these errors, promises are not readable enough and it's hard to see if error is propagation properly.


Example code to reproduce:

```js
usb.on('connect', (event) => {
  console.log('Device connected.');
});

usb.on('disconnect', (event) => {
  console.log('Connected.');
});

// request device so we can track the connect/disconnect events
usb.requestDevice({
  filters: [{}]
});
```
