### PR TITLE
Separate allowed devices and connected devices.

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,30 @@
+
+import { ok } from "assert";
+import { USBDevice } from "./device";
+
+/**
+ * @param num - must be short int(2 bytes).
+ * encodes short int to hex. (Always return 4 byte hex)
+ */
+
+export function encodeU16ToHex(num: number): string {
+    ok((num & 0xffff) === num);
+    const hex = num.toString(16);
+
+    return "0".repeat(4 - hex.length) + hex;
+}
+
+/**
+ * This will encode device to string for mapping.
+ * Format will be concatination of:
+ *  `0000-ffff` - hex of vendorId (short int)
+ *  `0000-ffff` - hex of productId (short int)
+ *  `...` - serial number is optional string.
+ */
+
+export function deviceToKey(device: USBDevice): string {
+    const vendorId = encodeU16ToHex(device.vendorId);
+    const productId = encodeU16ToHex(device.productId);
+
+    return vendorId + productId + device.serialNumber;
+}


### PR DESCRIPTION
PR #62 introduces a bug. Allowed devices is add only and we should not remove devices from that list. But we don't want to list allowed devices as actual devices, instead we should have connected device list. (issue #55). This PR separates those two. 

There is one notable assumption made with this PR, that `vendorID`(4 byte hex) + `productID`(4 byte hex) + `serialNumber` (stringified) can uniquely identify devices and called `key`. This logic is compatible with the previous logic but instead uses Maps to store connected devices and Set of those keys to list allowed devices.

UPDATE:

Another issue that #62 introduced is listening by default, which will keep the process alive.
I am thinking of removing list of `connected` device list fully, both from `usb` interface and `adapter`.

Without listener it will go out of sync, but listeners can not be cleaned up without introducing new methods (that wont be compatible with WebUSB). So instead of keeping list, we could query list of devices every time even though it's much more expensive.

On the other side, we could have "smart" logic, to optimize to keeping lists in case there are listeners, but query slow version when there are not.
