### PR TITLE
make device selector async.

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,7 +33,7 @@ export interface USBOptions {
     /**
      * A `device found` callback function to allow the user to select a device
      */
-    devicesFound?: (devices: Array<USBDevice>, selectFn?: (device: USBDevice) => void) => USBDevice | void;
+    devicesFound?: (devices: Array<USBDevice>) => Promise<USBDevice | void>;
 }
 
 /**


### PR DESCRIPTION
Note: Unfortunately, this is breaking change.

For terminal UI, or selected device with little bit more complicated logic (that requires async operations) will not be able to use current API.

With this it's possible to build UI or do more advanced selecting.

I also removed second parameter `selectFn`, because I believe it can be misleading for API consumers. It can be called by the user and still return another device which in turn will `resolve` promise twice, so instead we don't expose `selectFn` and `devicesFound` will just return device or void.

I also added another check for `USBDevice` for javascript consumers.